### PR TITLE
Reduce size of published exe

### DIFF
--- a/Adamite/Adamite.csproj
+++ b/Adamite/Adamite.csproj
@@ -8,4 +8,26 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <!-- Turn off unused features so they can be trimmed. See https://github.com/dotnet/winforms/issues/9911 -->
+  <PropertyGroup Condition="'$(DesignTimeBuild)' != 'true'">
+    <XmlResolverIsNetworkingEnabledByDefault>false</XmlResolverIsNetworkingEnabledByDefault>
+    <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <StackTraceSupport>false</StackTraceSupport>
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(DesignTimeBuild)' != 'true'">
+    <RuntimeHostConfigurationOption Include="System.ComponentModel.DefaultValueAttribute.IsSupported" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.ComponentModel.Design.IDesignerHost.IsSupported" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.Drawing.Design.UITypeEditor.IsSupported" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.Windows.Forms.ActiveXImpl.IsSupported" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.Windows.Forms.Binding.IsSupported" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.Windows.Forms.Control.AreDesignTimeFeaturesSupported" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.Windows.Forms.Control.UseComponentModelRegisteredTypes" Value="true" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.Windows.Forms.ImageIndexConverter.IsSupported" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.Windows.Forms.MdiWindowDialog.IsSupported" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.Windows.Forms.PictureBox.UseWebRequest" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.Windows.Forms.Primitives.TypeConverterHelper.UseComponentModelRegisteredTypes" Value="true" Trim="true" />
+  </ItemGroup>
+
 </Project>

--- a/Adamite/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Adamite/Properties/PublishProfiles/FolderProfile.pubxml
@@ -11,6 +11,9 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
-    <PublishReadyToRun>false</PublishReadyToRun>
+
+    <PublishAot>true</PublishAot>
+    <_SuppressWinFormsTrimError>true</_SuppressWinFormsTrimError>
+    <OptimizationPreference>size</OptimizationPreference>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
These changes reduce the size of the published exe to <9 MB by disabling unused features, trimming them, and using AOT compilation.
Based on comments from https://github.com/dotnet/winforms/issues/9911